### PR TITLE
feat: Functional component as default export

### DIFF
--- a/packages/babel-sugar-functional-vue/test/test.js
+++ b/packages/babel-sugar-functional-vue/test/test.js
@@ -31,6 +31,17 @@ const tests = [
 };`,
   },
   {
+    name: 'Default export functional component',
+    from: `export default ({ props, listeners }) => <div onClick={listeners.click}>{props.msg}</div>`,
+    to: `export default {
+  functional: true,
+  render: (h, {
+    props,
+    listeners
+  }) => <div onClick={listeners.click}>{props.msg}</div>
+};`,
+  },
+  {
     name: 'Named functional component in DevMode',
     NODE_ENV: 'development',
     from: `export const A = ({ props, listeners }) => <div onClick={listeners.click}>{props.msg}</div>`,


### PR DESCRIPTION
It should allow functional component as a default export:

``` jsx
export default ({ props }) => {
    return <div>{props}</div>
}
```

Added failing test @nickmessing 
